### PR TITLE
Lint fix for OPN generator

### DIFF
--- a/templates/database/model.tmpl
+++ b/templates/database/model.tmpl
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/bxcodec/faker/v3"
-{{- if .HasJson }}
+{{- if .HasJSON }}
     "gorm.io/datatypes"
 {{ end }}
 {{- if .HasDecimal }}


### PR DESCRIPTION
## Background
I found that `golint` recommend to use `HasJSON` instead of `HasJson`. It was fixed for OPN Generator. So, it's needed to fix here as well. 

## How this PR solves the issue
The `HasJson` was updated to `HasJSON` in OPN Generator. To make it compatible with this project, it's needed to be fixed here as well. 

N.B - This is an experimental fix. There is a possibility of a further fix after merge and test with the OPN Generator.